### PR TITLE
HOME-258 - Move SH-API to Debian

### DIFF
--- a/kubernetes/deployment.yaml
+++ b/kubernetes/deployment.yaml
@@ -26,5 +26,5 @@ spec:
       volumes:
         - name: mongo-db
           hostPath:
-            path: /data/db-backup
+            path: /data/db-shpanel
             type: Directory


### PR DESCRIPTION
**Business justification:** https://trello.com/c/eJIvWPk6/258-home-258-move-sh-api-to-debian

**Description:** As SH-API is being moved to Debian and mongo containers will backup data on the same physical machine, sh-api and sh-panel should have dedicated volume directories.

**Related PRs:**
* https://github.com/smart-evolution/shapi/pull/104
