### PR TITLE
HOME-262 - Fix APP_VERSION in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,8 +30,8 @@ after_success:
     if [[ ($TRAVIS_PULL_REQUEST == "false") && ($TRAVIS_COMMIT_MESSAGE =~ ^Build.*) ]]
     then
       echo "$DOCKER_PASS" | docker login -u "$DOCKER_LOGIN" --password-stdin
-      make image IMAGE_NAME=sh-panel ENV=prod V=$(APP_VERSION)
+      make image IMAGE_NAME=sh-panel ENV=prod V=$APP_VERSION
       docker push oszura/sh-panel-prod
-      make image IMAGE_NAME=sh-panel ENV=dev V=$(APP_VERSION)
+      make image IMAGE_NAME=sh-panel ENV=dev V=$APP_VERSION
       docker push oszura/sh-panel-dev
     fi


### PR DESCRIPTION
**Business justification:** https://trello.com/c/0PsImcE7/262-home-262-fix-appversion-in-travisyml

**Description:** `APP_VERISON` variable is not evaluated in `.travis.yml` within the braces, this PR removes them.