### PR TITLE
HOME-263 - Persist SH-API state in mongodb

### DIFF
--- a/client/modules/AgentsStatus/AddAgent/AddAgent.jsx
+++ b/client/modules/AgentsStatus/AddAgent/AddAgent.jsx
@@ -40,7 +40,7 @@ const AddAgent = (props: Props) => {
         </label>
         <input
           id="add-agent-name"
-          className="add-agent-name"
+          className="c-input__field"
           onChange={event => setAgentName(event.target.value)}
         />
       </div>

--- a/controllers/register.go
+++ b/controllers/register.go
@@ -12,7 +12,6 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-	"strings"
 )
 
 // Register - handle register page and register user process
@@ -59,14 +58,8 @@ func Register(w http.ResponseWriter, r *http.Request, opt router.UrlOptions, sm 
 		form.Add("password", password)
 
 		registerURL := "http://" + apiServer + ":" + os.Getenv("SH_API_SRV_PORT") + "/login/register"
-		rAPI, err := http.NewRequest("POST", registerURL, strings.NewReader(form.Encode()))
+		_, err = http.PostForm(registerURL, form)
 
-		if err != nil {
-			utils.Log("Error constructing register request to '" + apiServer + "' for the user '" + username + "'")
-		}
-
-		clientAPI := http.Client{}
-		_, err = clientAPI.Do(rAPI)
 		if err != nil {
 			fmt.Println(err)
 			utils.Log("Error registering user in endpoint " + registerURL)


### PR DESCRIPTION
**Business justification:** https://trello.com/c/qCVPeNDF/263-home-263-persist-sh-api-state-in-mongodb

**Description:** While working with `shapi` state persistance, few things in `shpanel` has to be adjusted:
* better error handling for users api controller
* posting new registered user mechanism is fixed
* small UI glitch fixed

**Related PRs:**
* https://github.com/smart-evolution/shapi/pull/109