### PR TITLE
HOME-284 - Refactor Cypress tests to use good practices

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,8 +29,8 @@ script:
     docker pull oszura/sh-influxdb:v1.0.0
     docker run -d --net=host oszura/sh-influxdb:v1.0.0
     sleep 10
-    docker pull oszura/sh-api-prod:v2.3.0
-    docker run -d --net=host oszura/sh-api-prod:v2.3.2
+    docker pull oszura/sh-api-prod:v2.4.0
+    docker run -d --net=host -e SH_ENV=test oszura/sh-api-prod:v2.4.0
     sleep 5
   - make image IMAGE_NAME=sh-panel ENV=prod V=$APP_VERSION
   - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,9 +34,9 @@ script:
     sleep 5
   - make image IMAGE_NAME=sh-panel ENV=prod V=$APP_VERSION
   - |
-    # docker run -d --net=host -e SH_PANEL_CONFIGCAT_KEY=$SH_PANEL_CONFIGCAT_KEY oszura/sh-panel-prod:$APP_VERSION
-    # sleep 5
-    # npm run cypress:run
+    docker run -d --net=host -e SH_PANEL_CONFIGCAT_KEY=$SH_PANEL_CONFIGCAT_KEY oszura/sh-panel-prod:$APP_VERSION
+    sleep 5
+    npm run cypress:run
 
 after_success:
   - |

--- a/cypress/integration/addAgent.spec.js
+++ b/cypress/integration/addAgent.spec.js
@@ -1,5 +1,6 @@
 describe('add agent', () => {
   before(function () {
+    cy.resetDb();
     cy.login();
   });
 

--- a/cypress/integration/loginPage.spec.js
+++ b/cypress/integration/loginPage.spec.js
@@ -1,4 +1,8 @@
 describe('Login page', () => {
+  before(function () {
+    cy.clearCookies();
+  });
+
   it('should render successfully', () => {
     cy.visit('http://localhost:3223');
     cy.screenshot();

--- a/cypress/integration/removeAgent.spec.js
+++ b/cypress/integration/removeAgent.spec.js
@@ -1,6 +1,15 @@
 describe('remove agent', () => {
   before(function () {
+    cy.resetDb();
     cy.login();
+
+    cy.get('.tst-nav-admin').click();
+
+    cy.get('.tst-add-agent-id').type('654302497');
+    cy.get('.tst-add-agent-ip').type('192.168.1.56');
+    cy.get('.tst-add-agent-name').type('Bedroom');
+    cy.get('.tst-add-agent-type').type('type1-v1.0.0');
+    cy.get('.tst-add-agent-submit').click();
   });
 
   beforeEach(function () {
@@ -9,6 +18,8 @@ describe('remove agent', () => {
   });
 
   it('should remove agent', () => {
+    cy.get('.tst-nav-dashboard').click();
+
     cy.get('.tst-agent-status-654302497').find('.agent-type1__link').click();
     cy.get('.tst-edit-btn').click();
     cy.get('.tst-delete').click();

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -11,3 +11,7 @@ Cypress.Commands.add('login', {}, () => {
   cy.get('.tst-password').type('admin');
   cy.get('.tst-login').click();
 });
+
+Cypress.Commands.add('resetDb', {}, () => {
+  cy.request('POST', 'http://localhost:3222/api/reset');
+});


### PR DESCRIPTION
**Business justification:** https://trello.com/c/cnJpHbWP/284-home-284-refactor-cypress-tests-to-use-good-practices

**Description:** Don't run Cypress tests in the way that some tests use state of the previous. Cypress tests should be independent from each other.

**Related PRs:**
* https://github.com/smart-evolution/shapi/pull/125